### PR TITLE
Support --load option

### DIFF
--- a/git_cc/rebase.py
+++ b/git_cc/rebase.py
@@ -35,12 +35,13 @@ def main(stash=False, dry_run=False, lshistory=False, load=None):
 
     since = getSince()
     cache.start()
+    loadFile = join(GIT_DIR, '.git', 'lshistory.bak')
     if load:
-        history = open(load, 'r').read().decode(ENCODING)
+        history = open(loadFile, 'r').read().decode(ENCODING)
     else:
         cc.rebase()
         history = getHistory(since)
-        write(join(GIT_DIR, '.git', 'lshistory.bak'), history.encode(ENCODING))
+        write(loadFile, history.encode(ENCODING))
     if lshistory:
         print(history)
     else:


### PR DESCRIPTION
Load doesn't work properly because load is a boolean and not the path to the load file. 
```
gitcc rebase --load
```
Specifying the load file also fails as it doesn't recognize that --load should have a value
```
gitcc rebase --load=".git/lshistory.bak"
```